### PR TITLE
Added humble branch

### DIFF
--- a/foros/include/akit/failover/foros/cluster_node.hpp
+++ b/foros/include/akit/failover/foros/cluster_node.hpp
@@ -135,16 +135,6 @@ class ClusterNode : public std::enable_shared_from_this<ClusterNode>,
       rclcpp::CallbackGroupType group_type,
       bool automatically_add_to_executor_with_node = true);
 
-  /// Return the list of callback groups in the node.
-  /**
-   * \return List of callback groups in the node.
-   * \deprecated
-   */
-  [[deprecated("get_callback_groups(): Not included in humble")]]
-  CLUSTER_NODE_PUBLIC
-  const std::vector<rclcpp::CallbackGroup::WeakPtr> &get_callback_groups()
-      const;
-
   /// Create a Publisher.
   /**
    * The rclcpp::QoS has several convenient constructors, including a

--- a/foros/include/akit/failover/foros/cluster_node.hpp
+++ b/foros/include/akit/failover/foros/cluster_node.hpp
@@ -135,7 +135,8 @@ class ClusterNode : public std::enable_shared_from_this<ClusterNode>,
       rclcpp::CallbackGroupType group_type,
       bool automatically_add_to_executor_with_node = true);
 
-  /// Iterate over the callback groups in the node, calling func on each valid one.
+  /// Iterate over the callback groups in the node, calling func on each valid
+  /// one.
   /**
    * From Humble, get_callback_groups() is replaced with this method.
    * https://github.com/ros2/rclcpp/pull/1723
@@ -144,7 +145,8 @@ class ClusterNode : public std::enable_shared_from_this<ClusterNode>,
    */
   CLUSTER_NODE_PUBLIC
   void for_each_callback_group(
-    const rclcpp::node_interfaces::NodeBaseInterface::CallbackGroupFunction & func);
+      const rclcpp::node_interfaces::NodeBaseInterface::CallbackGroupFunction
+          &func);
 
   /// Create a Publisher.
   /**

--- a/foros/include/akit/failover/foros/cluster_node.hpp
+++ b/foros/include/akit/failover/foros/cluster_node.hpp
@@ -138,7 +138,9 @@ class ClusterNode : public std::enable_shared_from_this<ClusterNode>,
   /// Return the list of callback groups in the node.
   /**
    * \return List of callback groups in the node.
+   * \deprecated
    */
+  [[deprecated("get_callback_groups(): Not included in humble")]]
   CLUSTER_NODE_PUBLIC
   const std::vector<rclcpp::CallbackGroup::WeakPtr> &get_callback_groups()
       const;

--- a/foros/include/akit/failover/foros/cluster_node.hpp
+++ b/foros/include/akit/failover/foros/cluster_node.hpp
@@ -135,6 +135,17 @@ class ClusterNode : public std::enable_shared_from_this<ClusterNode>,
       rclcpp::CallbackGroupType group_type,
       bool automatically_add_to_executor_with_node = true);
 
+  /// Iterate over the callback groups in the node, calling func on each valid one.
+  /**
+   * From Humble, get_callback_groups() is replaced with this method.
+   * https://github.com/ros2/rclcpp/pull/1723
+   *
+   * \param[in] func The callback function to call on each valid callback group.
+   */
+  CLUSTER_NODE_PUBLIC
+  void for_each_callback_group(
+    const rclcpp::node_interfaces::NodeBaseInterface::CallbackGroupFunction & func);
+
   /// Create a Publisher.
   /**
    * The rclcpp::QoS has several convenient constructors, including a

--- a/foros/include/akit/failover/foros/cluster_node_publisher.hpp
+++ b/foros/include/akit/failover/foros/cluster_node_publisher.hpp
@@ -72,7 +72,7 @@ class ClusterNodePublisher : public rclcpp::Publisher<MessageT, Alloc> {
    *
    * \param[in] msg a message to publish.
    */
-  void publish(std::unique_ptr<MessageT, MessageDeleter> msg) override {
+  void publish(std::unique_ptr<MessageT, MessageDeleter> msg) {
     if (node_lifecycle_interface_ != nullptr &&
         !node_lifecycle_interface_->is_activated()) {
       // ignore publish request when publisher is not activated
@@ -88,7 +88,7 @@ class ClusterNodePublisher : public rclcpp::Publisher<MessageT, Alloc> {
    *
    * \param[in] msg a message to publish.
    */
-  void publish(const MessageT& msg) override {
+  void publish(const MessageT& msg) {
     if (node_lifecycle_interface_ != nullptr &&
         !node_lifecycle_interface_->is_activated()) {
       // ignore publish request when publisher is not activated

--- a/foros/src/cluster_node.cpp
+++ b/foros/src/cluster_node.cpp
@@ -119,11 +119,6 @@ rclcpp::CallbackGroup::SharedPtr ClusterNode::create_callback_group(
       group_type, automatically_add_to_executor_with_node);
 }
 
-const std::vector<rclcpp::CallbackGroup::WeakPtr>
-    &ClusterNode::get_callback_groups() const {
-  return node_base_->get_callback_groups();
-}
-
 const rclcpp::ParameterValue &ClusterNode::declare_parameter(
     const std::string &name, const rclcpp::ParameterValue &default_value,
     const rcl_interfaces::msg::ParameterDescriptor &parameter_descriptor,

--- a/foros/src/cluster_node.cpp
+++ b/foros/src/cluster_node.cpp
@@ -119,6 +119,11 @@ rclcpp::CallbackGroup::SharedPtr ClusterNode::create_callback_group(
       group_type, automatically_add_to_executor_with_node);
 }
 
+void ClusterNode::for_each_callback_group(
+    const rclcpp::node_interfaces::NodeBaseInterface::CallbackGroupFunction & func) {
+  node_base_->for_each_callback_group(func);
+}
+
 const rclcpp::ParameterValue &ClusterNode::declare_parameter(
     const std::string &name, const rclcpp::ParameterValue &default_value,
     const rcl_interfaces::msg::ParameterDescriptor &parameter_descriptor,

--- a/foros/src/cluster_node.cpp
+++ b/foros/src/cluster_node.cpp
@@ -120,7 +120,8 @@ rclcpp::CallbackGroup::SharedPtr ClusterNode::create_callback_group(
 }
 
 void ClusterNode::for_each_callback_group(
-    const rclcpp::node_interfaces::NodeBaseInterface::CallbackGroupFunction & func) {
+    const rclcpp::node_interfaces::NodeBaseInterface::CallbackGroupFunction
+        &func) {
   node_base_->for_each_callback_group(func);
 }
 

--- a/foros/test/test_raft.hpp
+++ b/foros/test/test_raft.hpp
@@ -112,7 +112,7 @@ class TestContext : public akit::failover::foros::raft::Context {
     request->prev_log_index = prev_log_index;
     request->prev_log_term = prev_log_term;
     request->entries = entries;
-    return append_entries_->async_send_request(request);
+    return append_entries_->async_send_request(request).future.share();
   }
 
  private:


### PR DESCRIPTION
This framework is pretty excited! I have tested this on ROS 2 humble ant it works well!
Since ROS 2 API was changed, however, it is needed to modify some files.
I would expect someone want to run this on humble. I added comments for what I changed.

1. https://github.com/42dot/foros/commit/2f877f5f51f3b8523859add2c0b530e9d46720b1
[rclcpp/client.hpp/SharedFuture()](https://github.com/ros2/rclcpp/blob/7f575103d8fe06285bd46474a0324c7dfbb2a2f0/rclcpp/include/rclcpp/client.hpp#L408-L415) was deprecated. 
So I added a conversion.

2. https://github.com/42dot/foros/commit/5a427e793677841f9780c245ece675c7fac2a37a
[rclcpp/node_interfaces/node_base/get_callback_group()](https://github.com/ros2/rclcpp/blob/7f575103d8fe06285bd46474a0324c7dfbb2a2f0/rclcpp/include/rclcpp/node_interfaces/node_base.hpp#L89-L110) wasn't supported on humble. 
I added deprecated log on that function and deleted a declared function in cpp.

3. https://github.com/42dot/foros/commit/2c8c77df66c510eeb821b6dc165c2f5e4f55484b
[rclcpp/publisher/publisher()](https://github.com/ros2/rclcpp/blob/7f575103d8fe06285bd46474a0324c7dfbb2a2f0/rclcpp/include/rclcpp/publisher.hpp#L235-L273) was changed. This function hasn't be permitted overriding. 
I deleted an override option in cluster_node_publisher.cpp.

Thank you for sharing this project :) and hope to see you in ROSCon 2022.

